### PR TITLE
feat: Add shells for building the Linux app

### DIFF
--- a/shells/coda-core.nix
+++ b/shells/coda-core.nix
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 Collabora Productivity Limited
+#
+# SPDX-License-Identifier: MIT
+
+import ./core.nix

--- a/shells/coda-online.nix
+++ b/shells/coda-online.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2025 Collabora Productivity Limited
+#
+# SPDX-License-Identifier: MIT
+
+{ config }:
+{
+  kdePackages,
+  stdenv,
+  ...
+}:
+config.shells.online.result.x86_64-linux.overrideAttrs (old: {
+   nativeBuildInputs = old.nativeBuildInputs ++ [
+    kdePackages.qtbase.dev
+    kdePackages.qttools
+    (stdenv.mkDerivation {
+      name = "qtlibexec";
+
+      src = kdePackages.qtbase;
+
+      buildPhase = ''
+        mkdir -p $out
+        ln -s ${kdePackages.qtbase}/libexec $out/bin
+      '';
+    })
+    kdePackages.qtbase
+    kdePackages.qtwebengine
+    kdePackages.wrapQtAppsHook
+  ];
+})


### PR DESCRIPTION
Add shells for building the Collabora Office Linux app.

coda-online.nix is the online shell with the additional qt packages to build the desktop app.

coda-core.nix is th exact same as core.nix; currently you can even use the same build of core for both browser and desktop. However, this shell exists to allow for later changes that would make the core builds incompatible.